### PR TITLE
allow multi-level factor outcomes for GCM test

### DIFF
--- a/R/comet.R
+++ b/R/comet.R
@@ -26,6 +26,8 @@
 comet <- function(formula, data, test = c("gcm", "pcm", "wgcm"), ...) {
   fm <- Formula::as.Formula(formula)
   Y <- stats::model.response(model.frame(fm, data))
+  if (is.factor(Y) && length(levels(Y)) > 2)
+    Y <- .rm_int(stats::model.matrix(~ Y))
   X <- .rm_int(stats::model.matrix(fm, data, rhs = 1))
   Z <- .rm_int(stats::model.matrix(fm, data, rhs = 2))
   test <- match.fun(match.arg(test))

--- a/R/gcm.R
+++ b/R/gcm.R
@@ -121,18 +121,18 @@ gcm <- function(Y, X, Z, alternative = c("two.sided", "less", "greater"),
   y - pred
 }
 
-.check_data <- function(x, mode = c("Y", "X", "Z")) {
+.check_data <- function(x, mode = c("Y", "X", "Z"), test = "gcm") {
   mode <- match.arg(mode)
   if (mode == "Y") {
+    N <- NROW(x)
     if (!is.matrix(x) & !is.data.frame(x)) {
-      N <- NROW(x)
       ret <- c(x)
       if (is.factor(ret) && length(levels(ret)) > 2)
         stop("Only binary factors are allowed for Y.")
-      if (N != NROW(ret))
-        stop("Please provide Y as a vector.")
       return(ret)
     } else {
+      if (NCOL(x) > 1 && test == "pcm")
+        stop("Please provide Y as a vector.")
       .check_data(x, mode = "X")
     }
   }

--- a/R/pcm.R
+++ b/R/pcm.R
@@ -73,9 +73,9 @@ pcm <- function(Y, X, Z, rep = 1, est_vhat = TRUE, reg_YonXZ = "rf",
                 args_VonXZ = list(mtry = identity),
                 args_RonZ = list(mtry = identity),
                 frac = 0.5, coin = FALSE, cointrol = NULL, ...) {
-  Y <- .check_data(Y, "Y")
-  X <- .check_data(X, "X")
-  Z <- .check_data(Z, "Z")
+  Y <- .check_data(Y, "Y", "pcm")
+  X <- .check_data(X, "X", "pcm")
+  Z <- .check_data(Z, "Z", "pcm")
   if (rep != 1) {
     pcms <- lapply(seq_len(rep), \(iter) {
       pcm(Y = Y, X = X, Z = Z, rep = 1, est_vhat = est_vhat,

--- a/R/wgcm.R
+++ b/R/wgcm.R
@@ -47,7 +47,7 @@
 wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
                  args_XonZ = NULL, args_wfun = NULL, frac = 0.5,
                  B = 499L, coin = FALSE, cointrol = NULL, ...) {
-  Y <- .check_data(Y, "Y")
+  Y <- .check_data(Y, "Y", "pcm")
   X <- .check_data(X, "X")
   Z <- .check_data(Z, "Z")
   alternative <- "greater"

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -100,6 +100,10 @@ test_that("Multi-dimensional GCM works", {
   colnames(Z) <- c("Z1", "Z2")
   Y <- cbind(rnorm(tn), rnorm(tn), rnorm(tn))
   expect_no_error(gcm1 <- gcm(Y, X, Z, reg_XonZ = "lasso", reg_YonZ = "lasso"))
+  ### With multi-level factor as Y
+  expect_no_error(comet(Species ~ Sepal.Length | Sepal.Width, data = iris))
+  expect_error(comet(Species ~ Sepal.Length | Sepal.Width, data = iris, test = "pcm"))
+  expect_error(comet(Species ~ Sepal.Length | Sepal.Width, data = iris, test = "wgcm"))
 })
 
 test_that("TRAM GCM works with coxph and survforest", {


### PR DESCRIPTION
The following code no longer throws an exception (mutlivariate responses are now allowed for the GCM test, including multi-level factor variables):

```r
library("comets")
comet(Species ~ Sepal.Length | Sepal.Width, data = iris)
```