### PR TITLE
Bug fix

### DIFF
--- a/R/pcm.R
+++ b/R/pcm.R
@@ -99,6 +99,9 @@ pcm <- function(
     pcms <- lapply(seq_len(rep), \(iter) {
       call$rep <- 1
       call$indices <- indices[iter]
+      call$Y <- Y
+      call$X <- X
+      call$Z <- Z
       eval(call)
     })
     stat <- mean(unlist(lapply(pcms, \(tst) tst$statistic)))


### PR DESCRIPTION
When using `rep > 1` in `pcm()`, `eval(call)` can produce strange behavior when `Y`, `X`, `Z` are part of the global environment. The data used in call are now overwritten to avoid this.