### PR TITLE
Allow multivariate Y onZ and X on Z regressions for the GCM and wGCM test.

### DIFF
--- a/R/wgcm.R
+++ b/R/wgcm.R
@@ -49,11 +49,14 @@
 wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
                  args_YonZ = NULL, args_XonZ = NULL, args_wfun = NULL, frac = 0.5,
                  B = 499L, coin = TRUE, cointrol = NULL,
-                 return_fitted_models = FALSE, ...) {
+                 return_fitted_models = FALSE, multivariate = c("none", "YonZ", "XonZ", "both"),
+                 ...) {
   Y <- .check_data(Y, "Y", "pcm")
   X <- .check_data(X, "X")
   Z <- .check_data(Z, "Z")
   alternative <- "greater"
+  multivariate <- match.arg(multivariate)
+  mvXonZ <- multivariate %in% c("XonZ", "both")
 
   ### Sample splitting
   dsp <- .split_sample(Y, X, Z, frac = frac)
@@ -68,7 +71,7 @@ wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
   wYZ <- do.call(reg_YonZ, c(list(y = Ytr, x = Ztr), args_YonZ))
   wrY <- stats::residuals(wYZ, response = Ytr, data = Ztr)
 
-  wXZ <- .multi_regression(Xtr, Ztr, reg_XonZ, args_XonZ, return_fitted_models)
+  wXZ <- .multi_regression(Xtr, Ztr, reg_XonZ, args_XonZ, return_fitted_models, mvXonZ)
   wrX <- wXZ[["residuals"]]
   wmX <- wXZ[["models"]]
 
@@ -81,7 +84,7 @@ wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
   ### GCM on test data with weights
   YZ <- do.call(reg_YonZ, c(list(y = Yte, x = Zte), args_YonZ))
   rY <- stats::residuals(YZ, response = Yte, data = Zte)
-  XZ <- .multi_regression(Xte, Zte, reg_XonZ, args_XonZ, return_fitted_models)
+  XZ <- .multi_regression(Xte, Zte, reg_XonZ, args_XonZ, return_fitted_models, mvXonZ)
   rX <- XZ[["residuals"]]
   mX <- XZ[["models"]]
 

--- a/R/wgcm.R
+++ b/R/wgcm.R
@@ -18,7 +18,7 @@
 #'     See \code{?\link[comets]{regressions}} for more detail.
 #' @param args_wfun Additional arguments passed to \code{reg_XonZ}.
 #' @param frac Relative size of train split.
-#' @param ... Additional arguments passed to \code{reg_YonZ}.
+#' @param ... Additional arguments currently ignored.
 #'
 #' @returns Object of class '\code{wgcm}' and '\code{htest}' with the following
 #' components:
@@ -47,14 +47,13 @@
 #' (wgcm1 <- wgcm(Y, X, Z))
 #'
 wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
-                 args_XonZ = NULL, args_wfun = NULL, frac = 0.5,
+                 args_YonZ = NULL, args_XonZ = NULL, args_wfun = NULL, frac = 0.5,
                  B = 499L, coin = TRUE, cointrol = NULL,
                  return_fitted_models = FALSE, ...) {
   Y <- .check_data(Y, "Y", "pcm")
   X <- .check_data(X, "X")
   Z <- .check_data(Z, "Z")
   alternative <- "greater"
-  args <- if (length(list(...)) > 0) list(...) else NULL
 
   ### Sample splitting
   dsp <- .split_sample(Y, X, Z, frac = frac)
@@ -66,7 +65,7 @@ wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
   Zte <- dsp$Zte
 
   ### Estimate weight function and compute weights
-  wYZ <- do.call(reg_YonZ, c(list(y = Ytr, x = Ztr), args))
+  wYZ <- do.call(reg_YonZ, c(list(y = Ytr, x = Ztr), args_YonZ))
   wrY <- stats::residuals(wYZ, response = Ytr, data = Ztr)
 
   wXZ <- .multi_regression(Xtr, Ztr, reg_XonZ, args_XonZ, return_fitted_models)
@@ -80,7 +79,7 @@ wgcm <- function(Y, X, Z, reg_YonZ = "rf", reg_XonZ = "rf", reg_wfun = "rf",
   W <- do.call("cbind", lapply(mW, \(mZ) sign(predict(mZ, data = Zte))))
 
   ### GCM on test data with weights
-  YZ <- do.call(reg_YonZ, c(list(y = Yte, x = Zte), args))
+  YZ <- do.call(reg_YonZ, c(list(y = Yte, x = Zte), args_YonZ))
   rY <- stats::residuals(YZ, response = Yte, data = Zte)
   XZ <- .multi_regression(Xte, Zte, reg_XonZ, args_XonZ, return_fitted_models)
   rX <- XZ[["residuals"]]

--- a/man/gcm.Rd
+++ b/man/gcm.Rd
@@ -18,6 +18,7 @@ gcm(
   coin = TRUE,
   cointrol = list(distribution = "asymptotic"),
   return_fitted_models = FALSE,
+  multivariate = c("none", "YonZ", "XonZ", "both"),
   ...
 )
 }
@@ -61,6 +62,11 @@ The default is \code{TRUE}.}
 
 \item{return_fitted_models}{Logical; whether to return the fitted regressions
 (default is \code{FALSE}).}
+
+\item{multivariate}{Character; specifying which regression can handle
+multivariate outcomes (\code{"none"}, \code{"YonZ"}, \code{"XonZ"}, or
+\code{"both"}). If \code{"none"}, then the regression is run using each
+column in Y (or X) as the response.}
 
 \item{...}{Additional arguments passed to \code{reg_YonZ}.}
 }

--- a/man/wgcm.Rd
+++ b/man/wgcm.Rd
@@ -11,6 +11,7 @@ wgcm(
   reg_YonZ = "rf",
   reg_XonZ = "rf",
   reg_wfun = "rf",
+  args_YonZ = NULL,
   args_XonZ = NULL,
   args_wfun = NULL,
   frac = 0.5,
@@ -39,6 +40,8 @@ X on Z. See \code{?\link[comets]{regressions}} for more detail.}
 estimating the weighting function.
 See \code{?\link[comets]{regressions}} for more detail.}
 
+\item{args_YonZ}{A list of named arguments passed to \code{reg_YonZ}.}
+
 \item{args_XonZ}{A list of named arguments passed to \code{reg_XonZ}.}
 
 \item{args_wfun}{Additional arguments passed to \code{reg_XonZ}.}
@@ -59,7 +62,7 @@ The default is \code{TRUE}.}
 \item{return_fitted_models}{Logical; whether to return the fitted regressions
 (default is \code{FALSE}).}
 
-\item{...}{Additional arguments passed to \code{reg_YonZ}.}
+\item{...}{Additional arguments currently ignored.}
 }
 \value{
 Object of class '\code{wgcm}' and '\code{htest}' with the following

--- a/man/wgcm.Rd
+++ b/man/wgcm.Rd
@@ -19,6 +19,7 @@ wgcm(
   coin = TRUE,
   cointrol = NULL,
   return_fitted_models = FALSE,
+  multivariate = c("none", "YonZ", "XonZ", "both"),
   ...
 )
 }
@@ -61,6 +62,11 @@ The default is \code{TRUE}.}
 
 \item{return_fitted_models}{Logical; whether to return the fitted regressions
 (default is \code{FALSE}).}
+
+\item{multivariate}{Character; specifying which regression can handle
+multivariate outcomes (\code{"none"}, \code{"YonZ"}, \code{"XonZ"}, or
+\code{"both"}). If \code{"none"}, then the regression is run using each
+column in Y (or X) as the response.}
 
 \item{...}{Additional arguments currently ignored.}
 }

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -265,3 +265,16 @@ test_that("rf works with different response types", {
     comet(mcc ~ bin | x, data = dat)
   })
 })
+
+test_that("GCM with multivariate regressions works", {
+  devtools::load_all()
+  set.seed(12)
+  tn <- 3e2
+  set.seed(12)
+  X <- matrix(rnorm(2 * tn), ncol = 2)
+  colnames(X) <- c("X1", "X2")
+  Z <- matrix(rnorm(2 * tn), ncol = 2)
+  colnames(Z) <- c("Z1", "Z2")
+  Y <- cbind(Y1 = rnorm(tn), Y2 = rnorm(tn), Y3 = rnorm(tn))
+  expect_no_error(gcm1 <- gcm(Y, X, Z, reg_XonZ = "lrm", reg_YonZ = "lrm", multivariate = "both"))
+})


### PR DESCRIPTION
Adding argument `multivariate` to `gcm()` and `wgcm()`, which allows the specification of multivariate regression methods.