### PR TITLE
Change default for lasso and ridge regression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description: Covariance measure tests for conditional independence testing
     <doi:10.1080/01621459.2024.2395588>). Application examples to variable
     significance testing and modality selection can be found in Kook and
     Lundborg (2024, <doi:10.1093/bib/bbae475>).
-Depends: R (>= 4.1.0)
+Depends: R (>= 4.2.0)
 Imports: ranger, glmnet, Formula, survival, coin
 License: GPL-3
 Encoding: UTF-8

--- a/R/regressions.R
+++ b/R/regressions.R
@@ -174,9 +174,12 @@ residuals.glrm <- function(object, response = NULL, data = NULL, ...) {
 }
 
 #' @importFrom glmnet cv.glmnet
+#' @param s Which lambda to use for prediction, defaults to
+#'     \code{"lambda.min"}. See \code{\link[glmnet]{cv.glmnet}}
 #' @rdname regressions
-lasso <- function(y, x, ...) {
+lasso <- function(y, x, s = "lambda.min", ...) {
   obj <- cv.glmnet(y = y, x = as.matrix(x), ...)
+  obj$s <- s
   class(obj) <- c("lasso", class(obj))
   obj
 }
@@ -184,7 +187,7 @@ lasso <- function(y, x, ...) {
 #' @exportS3Method predict lasso
 predict.lasso <- function(object, data = NULL, ...) {
   class(object) <- class(object)[-1]
-  predict(object, newx = as.matrix(data), s = "lambda.1se")[, 1]
+  predict(object, newx = as.matrix(data), s = object$s)[, 1]
 }
 
 #' @exportS3Method residuals lasso
@@ -194,16 +197,17 @@ residuals.lasso <- function(object, response = NULL, data = NULL, ...) {
 }
 
 #' @rdname regressions
-ridge <- function(y, x, ...) {
+ridge <- function(y, x, s = "lambda.min", ...) {
   obj <- cv.glmnet(y = y, x = as.matrix(x), alpha = 0, ...)
+  obj$s <- s
   class(obj) <- c("lasso", class(obj))
   obj
 }
 
 #' @rdname regressions
-postlasso <- function(y, x, ...) {
+postlasso <- function(y, x, s = "lambda.min", ...) {
   obj <- cv.glmnet(y = y, x = as.matrix(x), ...)
-  nz <- which(stats::coef(obj, s = "lambda.1se")[-1] != 0)
+  nz <- which(stats::coef(obj, s = s)[-1] != 0)
   obj <- if (!identical(nz, integer(0))) {
     stats::lm(y ~ x[, nz])
   } else {

--- a/man/regressions.Rd
+++ b/man/regressions.Rd
@@ -25,11 +25,11 @@ lrm(y, x, ...)
 
 glrm(y, x, ...)
 
-lasso(y, x, ...)
+lasso(y, x, s = "lambda.min", ...)
 
-ridge(y, x, ...)
+ridge(y, x, s = "lambda.min", ...)
 
-postlasso(y, x, ...)
+postlasso(y, x, s = "lambda.min", ...)
 
 cox(y, x, ...)
 
@@ -68,6 +68,9 @@ In case of \code{"rf"}, \code{"tuned_rf"}, \code{"survforest"} and
 In case of \code{"cox"}, this is \code{\link[survival]{coxph}}. In case
 of \code{"xgb"} and \code{"tuned_xgb"} this is
 \code{\link[xgboost]{xgboost}}.}
+
+\item{s}{Which lambda to use for prediction, defaults to
+\code{"lambda.min"}. See \code{\link[glmnet]{cv.glmnet}}}
 
 \item{max.depths}{Values for \code{max.depth} to tune out-of-bag. See
 \code{\link[ranger]{ranger}}.}


### PR DESCRIPTION
Use `lambda.min` instead of `lambda.1se`, which empirically has better type I error control.